### PR TITLE
CAP_120_NS fixed admin/edit-role and DeleteUser to require Admin Role

### DIFF
--- a/API/Controllers/AdminController.cs
+++ b/API/Controllers/AdminController.cs
@@ -33,6 +33,7 @@ namespace API.Controllers
             return Ok(users);
         }
 
+        [Authorize(Policy = "RequireAdminRole")]
         [HttpPost("edit-roles/{username}")]
         public async Task<ActionResult> EditRoles(string username, [FromQuery] string roles)
         {
@@ -55,6 +56,7 @@ namespace API.Controllers
             return Ok(await _userManager.GetRolesAsync(user));
         }
 
+        [Authorize(Policy = "RequireAdminRole")]
         [HttpDelete("{username}")]
         public async Task<ActionResult> DeleteUser(string username)
         {


### PR DESCRIPTION
For some reason the Authorize attribute at the top doesn't cascade down to other methods....